### PR TITLE
Fix license header

### DIFF
--- a/apps/vmq_commons/src/vmq_topic.erl
+++ b/apps/vmq_commons/src/vmq_topic.erl
@@ -1,16 +1,17 @@
-%% The contents of this file are subject to the Mozilla Public License
-%% Version 1.1 (the "License"); you may not use this file except in
-%% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+
+%% Copyright 2019 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
 %%
-%% Software distributed under the License is distributed on an "AS IS"
-%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
-%% the License for the specific language governing rights and
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
 %% limitations under the License.
-%%
-%% Developer of the eMQTT Code is <ery.lee@gmail.com>
-%% Copyright (c) 2012 Ery Lee.  All rights reserved.
-%%
 -module(vmq_topic).
 
 -import(lists, [reverse/1]).


### PR DESCRIPTION
Some of the code was heavily inspired by one of the first versions of emqtt, when emqtt still used the MPL license. Therefore we kept the MPL license header and the appropriate copyright header. Since then this module has been rewritten, and a lot of functionality and tests were added. Moreover emqtt switched to Apache 2.0 too. I think it's time to change the license header in this file.